### PR TITLE
Fix theme parsing bug

### DIFF
--- a/src/main/java/seedu/address/commons/core/GuiSettings.java
+++ b/src/main/java/seedu/address/commons/core/GuiSettings.java
@@ -29,7 +29,7 @@ public class GuiSettings implements Serializable {
         windowWidth = DEFAULT_WIDTH;
         windowHeight = DEFAULT_HEIGHT;
         windowCoordinates = null; // null represent no coordinates
-        theme = Theme.DARKTHEME;
+        theme = Theme.DARK;
     }
 
     /**
@@ -55,7 +55,7 @@ public class GuiSettings implements Serializable {
     }
 
     public Theme getDefaultTheme() {
-        return Theme.DARKTHEME;
+        return Theme.DARK;
     }
 
     public Theme getTheme() {

--- a/src/main/java/seedu/address/commons/core/Theme.java
+++ b/src/main/java/seedu/address/commons/core/Theme.java
@@ -4,5 +4,6 @@ package seedu.address.commons.core;
  * Represents the available themes for the application.
  */
 public enum Theme {
-    LIGHTTHEME, DARKTHEME,
+    LIGHT,
+    DARK,
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -6,7 +6,6 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
-import seedu.address.commons.core.Theme;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -168,26 +167,5 @@ public class ParserUtil {
             throw new ParseException(EndTime.MESSAGE_CONSTRAINTS);
         }
         return new EndTime(trimmedEnd);
-    }
-
-    /**
-     * Parses a theme string into a Theme enum value.
-     *
-     * @param theme The theme string to parse.
-     * @return The corresponding Theme enum value.
-     * @throws ParseException If the theme string does not match any known theme.
-     */
-    public static Theme parseTheme(String theme) throws ParseException {
-        Theme guiTheme;
-        switch(theme.toUpperCase()) {
-        case "LIGHT":
-            guiTheme = Theme.LIGHTTHEME;
-            break;
-        case "DARK":
-            // Fall through
-        default:
-            guiTheme = Theme.DARKTHEME;
-        }
-        return guiTheme;
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ThemeCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ThemeCommandParser.java
@@ -31,7 +31,18 @@ public class ThemeCommandParser implements Parser<ThemeCommand> {
         }
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_THEME);
 
-        Theme theme = ParserUtil.parseTheme(argMultimap.getValue(PREFIX_THEME).get());
+        Theme theme;
+        String themeString = argMultimap.getValue(PREFIX_THEME).orElse(null).toUpperCase();
+
+        if (themeString == null) {
+            throw new ParseException("Theme value is null.");
+        }
+
+        try {
+            theme = Theme.valueOf(themeString);
+        } catch (IllegalArgumentException e) {
+            throw new ParseException("Theme does not exist: " + themeString);
+        }
 
         return new ThemeCommand(theme);
     }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -156,10 +156,10 @@ public class MainWindow extends UiPart<Stage> {
         String styleSheet;
         Theme theme = guiSettings.getTheme();
         switch(theme) {
-        case LIGHTTHEME:
+        case LIGHT:
             styleSheet = "/view/stylesheets/LightTheme.css";
             break;
-        case DARKTHEME:
+        case DARK:
         default:
             styleSheet = "/view/stylesheets/DarkTheme.css";
         }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -39,7 +39,7 @@ public class ModelManagerTest {
     public void setUserPrefs_validUserPrefs_copiesUserPrefs() {
         UserPrefs userPrefs = new UserPrefs();
         userPrefs.setAddressBookFilePath(Paths.get("address/book/file/path"));
-        userPrefs.setGuiSettings(new GuiSettings((double) 1000, (double) 500, 300, 100, "DARKTHEME"));
+        userPrefs.setGuiSettings(new GuiSettings((double) 1000, (double) 500, 300, 100, "DARK"));
         modelManager.setUserPrefs(userPrefs);
         assertEquals(userPrefs, modelManager.getUserPrefs());
 
@@ -56,7 +56,7 @@ public class ModelManagerTest {
 
     @Test
     public void setGuiSettings_validGuiSettings_setsGuiSettings() {
-        GuiSettings guiSettings = new GuiSettings((double) 1000, (double) 500, 300, 100, "DARKTHEME");
+        GuiSettings guiSettings = new GuiSettings((double) 1000, (double) 500, 300, 100, "DARK");
         modelManager.setGuiSettings(guiSettings);
         assertEquals(guiSettings, modelManager.getGuiSettings());
     }

--- a/src/test/java/seedu/address/storage/JsonUserPrefsStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonUserPrefsStorageTest.java
@@ -72,7 +72,7 @@ public class JsonUserPrefsStorageTest {
 
     private UserPrefs getTypicalUserPrefs() {
         UserPrefs userPrefs = new UserPrefs();
-        userPrefs.setGuiSettings(new GuiSettings((double) 1000, (double) 500, 300, 100, "DARKTHEME"));
+        userPrefs.setGuiSettings(new GuiSettings((double) 1000, (double) 500, 300, 100, "DARK"));
         userPrefs.setAddressBookFilePath(Paths.get("addressbook.json"));
         return userPrefs;
     }
@@ -103,7 +103,7 @@ public class JsonUserPrefsStorageTest {
     public void saveUserPrefs_allInOrder_success() throws DataLoadingException, IOException {
 
         UserPrefs original = new UserPrefs();
-        original.setGuiSettings(new GuiSettings((double) 1000, (double) 500, 300, 100, "DARKTHEME"));
+        original.setGuiSettings(new GuiSettings((double) 1000, (double) 500, 300, 100, "DARK"));
 
         Path pefsFilePath = testFolder.resolve("TempPrefs.json");
         JsonUserPrefsStorage jsonUserPrefsStorage = new JsonUserPrefsStorage(pefsFilePath);
@@ -114,7 +114,7 @@ public class JsonUserPrefsStorageTest {
         assertEquals(original, readBack);
 
         //Try saving when the file exists
-        original.setGuiSettings(new GuiSettings((double) 1000, (double) 500, 300, 100, "DARKTHEME"));
+        original.setGuiSettings(new GuiSettings((double) 1000, (double) 500, 300, 100, "DARK"));
         jsonUserPrefsStorage.saveUserPrefs(original);
         readBack = jsonUserPrefsStorage.readUserPrefs().get();
         assertEquals(original, readBack);

--- a/src/test/java/seedu/address/storage/StorageManagerTest.java
+++ b/src/test/java/seedu/address/storage/StorageManagerTest.java
@@ -41,7 +41,7 @@ public class StorageManagerTest {
          * More extensive testing of UserPref saving/reading is done in {@link JsonUserPrefsStorageTest} class.
          */
         UserPrefs original = new UserPrefs();
-        original.setGuiSettings(new GuiSettings((double) 1000, (double) 500, 300, 100, "DARKTHEME"));
+        original.setGuiSettings(new GuiSettings((double) 1000, (double) 500, 300, 100, "DARK"));
         storageManager.saveUserPrefs(original);
         UserPrefs retrieved = storageManager.readUserPrefs().get();
         assertEquals(original, retrieved);


### PR DESCRIPTION
Fixes #112

Dook accepts all -bg arguments for the theme command even when theme does not exit.

This commit fixes it and will instead display a theme not found message (see below).
<img width="483" alt="Screenshot 2024-03-28 at 2 39 53 PM" src="https://github.com/AY2324S2-CS2103T-W11-3/tp/assets/100476104/e2c8e8b3-9f86-49b0-b6df-49fa303a456d">

Also note that theme commands are now:
`theme -bg dark` and `theme -bg light` (dark and light are non-case sensitive)