### PR TITLE
Move CommandListPanel to HelpWindow to optimize focus

### DIFF
--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -1,14 +1,12 @@
 package seedu.address.ui;
 
-import java.awt.*;
+import java.awt.Desktop;
 import java.net.URI;
 import java.util.logging.Logger;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
-import javafx.scene.input.Clipboard;
-import javafx.scene.input.ClipboardContent;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
@@ -37,12 +35,6 @@ public class HelpWindow extends UiPart<Stage> {
     @FXML
     private StackPane commandListPanelPlaceholder; // Placeholder for dynamic content if needed
 
-    @FXML
-    private void initialize() {
-        CommandListPanel commandListPanel = new CommandListPanel();
-        commandListPanelPlaceholder.getChildren().add(commandListPanel.getRoot());
-    }
-
     /**
      * Creates a new HelpWindow.
      *
@@ -58,6 +50,18 @@ public class HelpWindow extends UiPart<Stage> {
      */
     public HelpWindow() {
         this(new Stage());
+    }
+
+
+    /**
+     * Initializes the controller class. This method is automatically called
+     * after the FXML file has been loaded. It instantiates the CommandListPanel
+     * and adds it to the placeholder stack pane in the Help window.
+     */
+    @FXML
+    private void initialize() {
+        CommandListPanel commandListPanel = new CommandListPanel();
+        commandListPanelPlaceholder.getChildren().add(commandListPanel.getRoot());
     }
 
     /**
@@ -125,3 +129,4 @@ public class HelpWindow extends UiPart<Stage> {
         }
     }
 }
+

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -1,5 +1,7 @@
 package seedu.address.ui;
 
+import java.awt.*;
+import java.net.URI;
 import java.util.logging.Logger;
 
 import javafx.fxml.FXML;
@@ -7,6 +9,8 @@ import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
+import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 import seedu.address.commons.core.LogsCenter;
 
@@ -16,7 +20,7 @@ import seedu.address.commons.core.LogsCenter;
 public class HelpWindow extends UiPart<Stage> {
 
     public static final String USERGUIDE_URL = "https://ay2324s2-cs2103t-w11-3.github.io/tp/UserGuide.html";
-    public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL;
+    public static final String HELP_MESSAGE = "For more information, refer to this user guide: ";
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);
     private static final String FXML = "HelpWindow.fxml";
@@ -26,6 +30,18 @@ public class HelpWindow extends UiPart<Stage> {
 
     @FXML
     private Label helpMessage;
+
+    @FXML
+    private VBox commandList; // Ensure this matches the fx:id of your CommandList VBox
+
+    @FXML
+    private StackPane commandListPanelPlaceholder; // Placeholder for dynamic content if needed
+
+    @FXML
+    private void initialize() {
+        CommandListPanel commandListPanel = new CommandListPanel();
+        commandListPanelPlaceholder.getChildren().add(commandListPanel.getRoot());
+    }
 
     /**
      * Creates a new HelpWindow.
@@ -90,13 +106,22 @@ public class HelpWindow extends UiPart<Stage> {
     }
 
     /**
-     * Copies the URL to the user guide to the clipboard.
+     * Opens the specified URL in the user's default web browser.
+     * This method checks if the Desktop class supports the BROWSE action.
+     * If supported, it attempts to open the given URL in the default browser.
+     * Logs an error if browsing is not supported or if an exception occurs.
      */
     @FXML
-    private void copyUrl() {
-        final Clipboard clipboard = Clipboard.getSystemClipboard();
-        final ClipboardContent url = new ClipboardContent();
-        url.putString(USERGUIDE_URL);
-        clipboard.setContent(url);
+    private void openUrlInBrowser() {
+        try {
+            URI uri = new URI(USERGUIDE_URL);
+            if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Desktop.Action.BROWSE)) {
+                Desktop.getDesktop().browse(uri);
+            } else {
+                System.err.println("Browsing not supported!");
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -51,9 +51,6 @@ public class MainWindow extends UiPart<Stage> {
     private StackPane bookingListPanelPlaceholder;
 
     @FXML
-    private StackPane commandListPanelPlaceholder;
-
-    @FXML
     private StackPane resultDisplayPlaceholder;
 
     @FXML
@@ -135,9 +132,6 @@ public class MainWindow extends UiPart<Stage> {
 
         CommandBox commandBox = new CommandBox(this::executeCommand);
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
-
-        CommandListPanel commandListPanel = new CommandListPanel();
-        commandListPanelPlaceholder.getChildren().add(commandListPanel.getRoot());
     }
 
     /**

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -230,3 +230,4 @@ public class MainWindow extends UiPart<Stage> {
     }
 
 }
+

--- a/src/main/resources/view/BookingListCard.fxml
+++ b/src/main/resources/view/BookingListCard.fxml
@@ -38,3 +38,4 @@
       </rowConstraints>
     </GridPane>
 </HBox>
+

--- a/src/main/resources/view/BookingListPanel.fxml
+++ b/src/main/resources/view/BookingListPanel.fxml
@@ -6,3 +6,4 @@
 <VBox alignment="TOP_RIGHT" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1">
     <ListView fx:id="bookingListView" VBox.vgrow="ALWAYS" />
 </VBox>
+

--- a/src/main/resources/view/CommandListPanel.fxml
+++ b/src/main/resources/view/CommandListPanel.fxml
@@ -5,3 +5,4 @@
 <VBox fx:id="commandListPanel" xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml/1">
     <ListView fx:id="commandListView" />
 </VBox>
+

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -72,3 +72,4 @@
     </Scene>
   </scene>
 </fx:root>
+

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -6,10 +6,13 @@
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.image.Image?>
+<?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.layout.VBox?>
 <?import javafx.stage.Stage?>
 
-<fx:root resizable="false" title="Help" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root resizable="false" title="Help" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/help_icon.png" />
   </icons>
@@ -17,28 +20,55 @@
     <Scene>
       <stylesheets>
         <URL value="@stylesheets/HelpWindow.css" />
+        <URL value="@stylesheets/DarkTheme.css" />
       </stylesheets>
-
-      <HBox alignment="CENTER" fx:id="helpMessageContainer">
-        <children>
-          <Label fx:id="helpMessage" text="Label">
-            <HBox.margin>
-              <Insets right="5.0" />
-            </HBox.margin>
-          </Label>
-          <Button fx:id="copyButton" mnemonicParsing="false" onAction="#copyUrl" text="Copy">
-            <HBox.margin>
-              <Insets left="5.0" />
-            </HBox.margin>
-          </Button>
-        </children>
-        <opaqueInsets>
-          <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />
-        </opaqueInsets>
-        <padding>
-          <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />
-        </padding>
-      </HBox>
+      <!-- Command List FXML -->
+      <VBox styleClass="BG" VBox.vgrow="ALWAYS">
+       <children>
+         <VBox fx:id="commandList" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
+           <HBox alignment="TOP_LEFT" spacing="5" styleClass="title-bar">
+             <StackPane styleClass="icon-container">
+               <ImageView fitHeight="35" fitWidth="35" preserveRatio="true">
+                 <Image url="@/images/terminal_icon.png" />
+               </ImageView>
+             </StackPane>
+             <Label styleClass="title-label" text="Commands">
+               <HBox.margin>
+                 <Insets />
+               </HBox.margin></Label>
+             <VBox.margin>
+               <Insets />
+             </VBox.margin>
+           </HBox>
+           <StackPane fx:id="commandListPanelPlaceholder" VBox.vgrow="ALWAYS">
+             <padding>
+               <Insets bottom="8.0" left="10.0" right="8.0" top="10.0" />
+             </padding>
+           </StackPane>
+           <HBox.margin>
+             <Insets bottom="8.0" right="10.0" top="5.0" />
+           </HBox.margin>
+           <VBox.margin>
+             <Insets bottom="10.0" left="5.0" right="5.0" top="10.0" />
+           </VBox.margin>
+         </VBox>
+         <HBox fx:id="helpMessageContainer" alignment="CENTER" VBox.vgrow="NEVER">
+           <Label fx:id="helpMessage" text="Label">
+             <HBox.margin>
+               <Insets right="5.0" />
+             </HBox.margin>
+           </Label>
+           <Button fx:id="copyButton" mnemonicParsing="false" onAction="#openUrlInBrowser" text="Take me to UG">
+           </Button>
+           <opaqueInsets>
+             <Insets bottom="10.0" left="5.0" right="10.0" top="5.0" />
+           </opaqueInsets>
+           <padding>
+             <Insets bottom="10.0" left="10.0" right="10.0" top="5.0" />
+           </padding>
+         </HBox>
+       </children>
+     </VBox>
     </Scene>
   </scene>
 </fx:root>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -14,8 +14,8 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.stage.Stage?>
 
-<?import javafx.scene.layout.Pane?>
-<fx:root minHeight="800" minWidth="1200" onCloseRequest="#handleExit" title="Dook" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root minHeight="800" minWidth="1200" onCloseRequest="#handleExit" title="Dook"
+         type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/21" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/address_book_32.png" />
   </icons>
@@ -35,6 +35,7 @@
           </Menu>
         </MenuBar>
 
+          <!-- Person List Card FXML -->
         <HBox VBox.vgrow="ALWAYS">
           <VBox fx:id="personList" minWidth="390" prefHeight="600" prefWidth="390" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
               <HBox alignment="CENTER_LEFT" spacing="5" styleClass="title-bar">
@@ -56,6 +57,7 @@
                      <Insets bottom="10.0" left="10.0" right="5.0" top="10.0" />
                   </HBox.margin>
           </VBox>
+            <!-- Booking List Card and Panel FXML -->
           <VBox HBox.hgrow="ALWAYS" VBox.vgrow="ALWAYS">
             <VBox fx:id="bookingList" minWidth="350" prefHeight="600" prefWidth="400" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
                 <HBox alignment="CENTER_LEFT" spacing="5" styleClass="title-bar">
@@ -81,6 +83,8 @@
                         <Insets top="5.0" />
                      </VBox.margin>
             </VBox>
+
+              <!-- Result Display FXML -->
             <StackPane fx:id="resultDisplayPlaceholder" maxHeight="200" minHeight="200" prefHeight="200" styleClass="pane-with-border" VBox.vgrow="NEVER">
               <padding>
                 <Insets bottom="5" left="10" right="10" top="5" />
@@ -90,6 +94,7 @@
                      </VBox.margin>
             </StackPane>
 
+              <!-- Command Box FXML -->
             <StackPane fx:id="commandBoxPlaceholder" styleClass="pane-with-border">
               <padding>
                 <Insets bottom="5" left="10" top="5" />
@@ -102,43 +107,6 @@
                      <Insets bottom="5.0" left="5.0" right="10.0" top="5.0" />
                   </HBox.margin>
           </VBox>
-            <VBox>
-                <VBox fx:id="commandList" minWidth="300.0" prefHeight="150.0" prefWidth="300.0" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
-                    <HBox alignment="TOP_LEFT" spacing="5" styleClass="title-bar">
-                        <StackPane styleClass="icon-container">
-                            <ImageView fitHeight="35" fitWidth="35" preserveRatio="true">
-                                <Image url="@/images/terminal_icon.png" />
-                            </ImageView>
-                        </StackPane>
-                        <Label styleClass="title-label" text="Commands">
-                           <HBox.margin>
-                              <Insets />
-                           </HBox.margin></Label>
-                        <VBox.margin>
-                           <Insets top="10.0" />
-                        </VBox.margin>
-                    </HBox>
-                    <StackPane fx:id="commandListPanelPlaceholder">
-                        <padding>
-                            <Insets bottom="8.0" left="10.0" right="8.0" top="10.0" />
-                        </padding>
-                    </StackPane>
-                    <HBox.margin>
-                        <Insets bottom="8.0" right="10.0" top="5.0" />
-                    </HBox.margin>
-                     <VBox.margin>
-                        <Insets right="10.0" top="10.0" />
-                     </VBox.margin>
-                </VBox>
-                <StackPane fx:id="calendar" minWidth="300.0" prefHeight="100" prefWidth="300.0" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
-                    <padding>
-                        <Insets bottom="8.0" left="10.0" right="8.0" top="10.0" />
-                    </padding>
-                     <VBox.margin>
-                        <Insets bottom="10.0" right="10.0" top="10.0" />
-                     </VBox.margin>
-                </StackPane>
-            </VBox>
         </HBox>
         <StackPane fx:id="statusbarPlaceholder" />
       </VBox>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -113,3 +113,4 @@
     </Scene>
   </scene>
 </fx:root>
+

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -71,3 +71,4 @@
          <Insets bottom="10.0" right="10.0" top="10.0" />
       </HBox.margin></ImageView>
 </HBox>
+

--- a/src/main/resources/view/PersonListPanel.fxml
+++ b/src/main/resources/view/PersonListPanel.fxml
@@ -6,3 +6,4 @@
 <VBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
   <ListView fx:id="personListView" VBox.vgrow="ALWAYS" />
 </VBox>
+

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -7,3 +7,4 @@
     xmlns:fx="http://javafx.com/fxml/1">
   <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display"/>
 </StackPane>
+

--- a/src/main/resources/view/StatusBarFooter.fxml
+++ b/src/main/resources/view/StatusBarFooter.fxml
@@ -10,3 +10,4 @@
   </columnConstraints>
   <Label fx:id="saveLocationStatus" />
 </GridPane>
+

--- a/src/main/resources/view/stylesheets/CommandListPanel.css
+++ b/src/main/resources/view/stylesheets/CommandListPanel.css
@@ -24,3 +24,4 @@
 .container {
     -fx-spacing: 0;
 }
+

--- a/src/main/resources/view/stylesheets/DarkTheme.css
+++ b/src/main/resources/view/stylesheets/DarkTheme.css
@@ -326,3 +326,4 @@
     -fx-background-radius: 15;
     -fx-font-size: 12;
 }
+

--- a/src/main/resources/view/stylesheets/Extensions.css
+++ b/src/main/resources/view/stylesheets/Extensions.css
@@ -13,3 +13,4 @@
 .tooltip-text {
     -fx-text-fill: white;
 }
+

--- a/src/main/resources/view/stylesheets/HelpWindow.css
+++ b/src/main/resources/view/stylesheets/HelpWindow.css
@@ -1,13 +1,17 @@
 #copyButton, #helpMessage {
     -fx-text-fill: white;
+    -fx-font-family: "Hack";
 }
 
 #copyButton {
+    -fx-font-weight: bold;
     -fx-background-color: dimgray;
+    -fx-border-radius: 75%;
+    -fx-background-radius: 14px;
 }
 
 #copyButton:hover {
-    -fx-background-color: gray;
+    -fx-background-color: #186ADD;
 }
 
 #copyButton:armed {

--- a/src/main/resources/view/stylesheets/HelpWindow.css
+++ b/src/main/resources/view/stylesheets/HelpWindow.css
@@ -21,3 +21,4 @@
 #helpMessageContainer {
     -fx-background-color: derive(#1d1d1d, 20%);
 }
+

--- a/src/main/resources/view/stylesheets/LightTheme.css
+++ b/src/main/resources/view/stylesheets/LightTheme.css
@@ -329,3 +329,4 @@
     -fx-background-radius: 15;
     -fx-font-size: 12;
 }
+


### PR DESCRIPTION
## Overview
This PR addresses a previously expressed need to enhance user focus by relocating the `CommandListPanel` from its original position to the `HelpWindow`. This strategic move aims to spotlight the primary feature, `BookingList`, by minimizing distractions and optimizing the user interface layout. Additionally, we have improved the functionality of the `Take me to UG` URL, enabling it to open directly in the user's default browser, thereby enhancing the user experience.

## Changes
- **CommandListPanel Relocation**: The `CommandListPanel` has been moved to the `HelpWindow` to streamline the user interface and focus attention on the `BookingList`.
- **Direct Link Opening**: Updated the `Take me to UG` **URL functionality**. It now opens the link directly in the user's default browser, as opposed to the previous behavior of merely copying the URL to the clipboard.

## Impact
- **Enhanced User Focus**: By moving the `CommandListPanel` to the `HelpWindow`, users can now concentrate more on the main feature, `BookingList`, improving the overall usability and experience.
- **Improved Accessibility**: The direct opening of the `Take me to UG` link in the default browser simplifies the process for users, making the user guide more accessible and user-friendly.

## Screenshots
### Help Window
<img width="561" alt="Screenshot 2024-03-28 at 2 56 50 PM" src="https://github.com/AY2324S2-CS2103T-W11-3/tp/assets/21017515/36e3f929-8feb-4802-ad8b-c3025825c3b1">

### Main Window
<img width="1192" alt="Screenshot 2024-03-28 at 2 57 36 PM" src="https://github.com/AY2324S2-CS2103T-W11-3/tp/assets/21017515/7428b3a0-399b-4951-8abd-45b9c97b7ebc">
