### PR TITLE
Fix various messages and documentation bugs

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -488,7 +488,7 @@ book -n DESCRIPTION -s START_TIME -e END_TIME -note NOTE
 
 | Param           | Remarks                                  |
 |-----------------|------------------------------------------|
-| **DESCRIPTION** | Must be non-null and unique              |
+| **DESCRIPTION** | Must be non-null                         |
 | **START_TIME**  | Must follow format of `2023-12-31 19:00` |
 | **END_TIME**    | Must follow format of `2023-12-31 19:00` |
 | **NOTE**        | Must be non-null                         |

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -49,7 +49,7 @@ public class EditCommand extends Command {
             + PREFIX_EMAIL + "johndoe@example.com";
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
-    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_NOT_EDITED = "At least one field must be changed.";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
 
     private final Index index;
@@ -81,6 +81,8 @@ public class EditCommand extends Command {
 
         if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+        } else if (personToEdit.equals(editedPerson)) {
+            throw new CommandException(MESSAGE_NOT_EDITED);
         }
 
         model.setPerson(personToEdit, editedPerson);

--- a/src/main/java/seedu/address/logic/commands/ProfCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ProfCommand.java
@@ -17,7 +17,7 @@ import seedu.address.model.person.exceptions.DuplicatePersonException;
 public class ProfCommand extends Command {
     public static final String COMMAND_WORD = "prof";
 
-    public static final String MESSAGE_SUCCESS = "Professors Added!";
+    public static final String MESSAGE_SUCCESS = "Professors Added: %d\nDuplicates found: %d";
     public static final String MESSAGE_FAILURE = "No professors found!\nPlease double check professors name.";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds professors to the address book.\n"
@@ -49,17 +49,21 @@ public class ProfCommand extends Command {
             throw new CommandException(MESSAGE_FAILURE);
         }
 
+        int profsAdded = 0;
+        int dupesFound = 0;
+
         for (Person person : model.getFilteredProfList()) {
             try {
                 model.addPerson(person);
+                profsAdded++;
             } catch (DuplicatePersonException e) {
-                throw new CommandException("Error: Professor already in contacts");
+                dupesFound++;
             }
         }
 
         // reset user view
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(MESSAGE_SUCCESS);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, profsAdded, dupesFound));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Address.java
+++ b/src/main/java/seedu/address/model/person/Address.java
@@ -52,7 +52,13 @@ public class Address {
         }
 
         Address otherAddress = (Address) other;
-        return value.equals(otherAddress.value);
+        if (this.value == null && otherAddress.value == null) {
+            return true;
+        } else if (this.value == null || otherAddress.value == null) {
+            return false;
+        } else {
+            return this.value.equals(otherAddress.value);
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -66,7 +66,13 @@ public class Email {
         }
 
         Email otherEmail = (Email) other;
-        return value.equals(otherEmail.value);
+        if (this.value == null && otherEmail.value == null) {
+            return true; // Both values are null, consider them equal
+        } else if (this.value == null || otherEmail.value == null) {
+            return false; // One value is null while the other is not, consider them not equal
+        } else {
+            return this.value.equals(otherEmail.value); // Compare non-null values
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -122,11 +122,25 @@ public class Person {
         }
 
         Person otherPerson = (Person) other;
-        return name.equals(otherPerson.name)
-                && phone.equals(otherPerson.phone)
-                && email.equals(otherPerson.email)
-                && address.equals(otherPerson.address)
-                && tags.equals(otherPerson.tags);
+
+        // Handle null checks for each attribute
+        boolean nameEquals = (this.name == null && otherPerson.name == null)
+                || (this.name != null && this.name.equals(otherPerson.name));
+
+        boolean phoneEquals = (this.phone == null && otherPerson.phone == null)
+                || (this.phone != null && this.phone.equals(otherPerson.phone));
+
+        boolean emailEquals = (this.email == null && otherPerson.email == null)
+                || (this.email != null && this.email.equals(otherPerson.email));
+
+        boolean addressEquals = (this.address == null && otherPerson.address == null)
+                || (this.address != null && this.address.equals(otherPerson.address));
+
+        boolean tagsEquals = (this.tags == null && otherPerson.tags == null)
+                || (this.tags != null && this.tags.equals(otherPerson.tags));
+
+        // Return true if all attributes are equal
+        return nameEquals && phoneEquals && emailEquals && addressEquals && tagsEquals;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -48,7 +48,13 @@ public class Phone {
         }
 
         Phone otherPhone = (Phone) other;
-        return value.equals(otherPhone.value);
+        if (this.value == null && otherPhone.value == null) {
+            return true; // Both values are null, consider them equal
+        } else if (this.value == null || otherPhone.value == null) {
+            return false; // One value is null while the other is not, consider them not equal
+        } else {
+            return this.value.equals(otherPhone.value); // Compare non-null values
+        }
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -53,6 +53,18 @@ public class EditCommandTest {
     }
 
     @Test
+    public void execute_noEditsMade_failure() {
+        // Test that editing first person without change leads to error
+        Person editedPerson = model.getFilteredPersonList().get(0);
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_NOT_EDITED);
+
+        assertCommandFailure(editCommand, model, expectedMessage);
+    }
+
+    @Test
     public void execute_someFieldsSpecifiedUnfilteredList_success() {
         Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
         Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
@@ -76,17 +88,13 @@ public class EditCommandTest {
     }
 
     @Test
-    public void execute_noFieldSpecifiedUnfilteredList_success() {
+    public void execute_noParamAddedUnfilteredList_failure() {
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, new EditPersonDescriptor());
         Person editedPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+        String expectedMessage = String.format(EditCommand.MESSAGE_NOT_EDITED);
 
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
-                new ProfData(model.getProfData()),
-                new UserPrefs());
-
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+        assertCommandFailure(editCommand, model, expectedMessage);
     }
 
     @Test


### PR DESCRIPTION
1. Closes #146
* Edit message will show `edited ...` no matter if any changes are made or not.
* Fix here was to check equality of Person objects and throw message if not changed

2. Closes #150
* Adding a professor would result in duplicate person message shown if there are duplicates
* This is incorrect as it does not show the user the status of the operation
* Lets update this to show how many profs added and how many duplicates
<img width="857" alt="Screenshot 2024-04-11 at 5 14 47 PM" src="https://github.com/AY2324S2-CS2103T-W11-3/tp/assets/100476104/14ca1829-2cae-414d-ba6f-6fd24d0bc1f3">

3. Closes #192 
* Trivial documentation bug