### PR TITLE
Fixes editing related bugs

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -496,7 +496,7 @@ book -n DESCRIPTION -s START_TIME -e END_TIME -note NOTE
 
 | Param           | Remarks                                  |
 |-----------------|------------------------------------------|
-| **DESCRIPTION** | Must be non-null and unique              |
+| **DESCRIPTION** | Must be non-null                         |
 | **START_TIME**  | Must follow format of `2023-12-31 19:00` |
 | **END_TIME**    | Must follow format of `2023-12-31 19:00` |
 | **NOTE**        | Must be non-null                         |

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -49,7 +49,7 @@ public class EditCommand extends Command {
             + PREFIX_EMAIL + "johndoe@example.com";
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
-    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_NOT_EDITED = "At least one field must be changed.";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
 
     private final Index index;
@@ -81,6 +81,8 @@ public class EditCommand extends Command {
 
         if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+        } else if (personToEdit.equals(editedPerson)) {
+            throw new CommandException(MESSAGE_NOT_EDITED);
         }
 
         model.setPerson(personToEdit, editedPerson);

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -10,7 +10,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_PHONE = new Prefix("-p ");
     public static final Prefix PREFIX_EMAIL = new Prefix("-e ");
     public static final Prefix PREFIX_ADDRESS = new Prefix("-a ");
-    public static final Prefix PREFIX_TAG = new Prefix("-t ");
+    public static final Prefix PREFIX_TAG = new Prefix("-t");
     public static final Prefix PREFIX_START_TIME = new Prefix("-s ");
     public static final Prefix PREFIX_END_TIME = new Prefix("-e ");
     public static final Prefix PREFIX_NOTES = new Prefix("-note ");

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -60,10 +60,6 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
 
-        if (!editPersonDescriptor.isAnyFieldEdited()) {
-            throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
-        }
-
         return new EditCommand(index, editPersonDescriptor);
     }
 

--- a/src/main/java/seedu/address/model/person/Address.java
+++ b/src/main/java/seedu/address/model/person/Address.java
@@ -52,7 +52,13 @@ public class Address {
         }
 
         Address otherAddress = (Address) other;
-        return value.equals(otherAddress.value);
+        if (this.value == null && otherAddress.value == null) {
+            return true;
+        } else if (this.value == null || otherAddress.value == null) {
+            return false;
+        } else {
+            return this.value.equals(otherAddress.value);
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -66,7 +66,13 @@ public class Email {
         }
 
         Email otherEmail = (Email) other;
-        return value.equals(otherEmail.value);
+        if (this.value == null && otherEmail.value == null) {
+            return true;
+        } else if (this.value == null || otherEmail.value == null) {
+            return false;
+        } else {
+            return this.value.equals(otherEmail.value);
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -122,11 +122,25 @@ public class Person {
         }
 
         Person otherPerson = (Person) other;
-        return name.equals(otherPerson.name)
-                && phone.equals(otherPerson.phone)
-                && email.equals(otherPerson.email)
-                && address.equals(otherPerson.address)
-                && tags.equals(otherPerson.tags);
+
+        // Handle null checks for each attribute
+        boolean nameEquals = (this.name == null && otherPerson.name == null)
+                || (this.name != null && this.name.equals(otherPerson.name));
+
+        boolean phoneEquals = (this.phone == null && otherPerson.phone == null)
+                || (this.phone != null && this.phone.equals(otherPerson.phone));
+
+        boolean emailEquals = (this.email == null && otherPerson.email == null)
+                || (this.email != null && this.email.equals(otherPerson.email));
+
+        boolean addressEquals = (this.address == null && otherPerson.address == null)
+                || (this.address != null && this.address.equals(otherPerson.address));
+
+        boolean tagsEquals = (this.tags == null && otherPerson.tags == null)
+                || (this.tags != null && this.tags.equals(otherPerson.tags));
+
+        // Return true if all attributes are equal
+        return nameEquals && phoneEquals && emailEquals && addressEquals && tagsEquals;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -48,7 +48,13 @@ public class Phone {
         }
 
         Phone otherPhone = (Phone) other;
-        return value.equals(otherPhone.value);
+        if (this.value == null && otherPhone.value == null) {
+            return true;
+        } else if (this.value == null || otherPhone.value == null) {
+            return false;
+        } else {
+            return this.value.equals(otherPhone.value);
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -3,12 +3,12 @@ package seedu.address.ui;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
 import javafx.scene.input.ScrollEvent;
 import javafx.scene.layout.Region;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
-
 
 /**
  * The UI component that is responsible for receiving user command inputs.
@@ -49,6 +49,14 @@ public class CommandBox extends UiPart<Region> {
                 commandTextField.positionCaret(commandTextField.getText().length());
             }
             setStyleToDefault();
+        });
+
+        commandTextField.setOnKeyPressed(event -> {
+            if (event.getCode() == KeyCode.UP) {
+                // Move the caret to the beginning of the text
+                commandTextField.positionCaret(2);
+                event.consume(); // Consume the event to prevent default behavior
+            }
         });
 
         setupScrollingOnCommandTextField();

--- a/src/test/java/seedu/address/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditCommandTest.java
@@ -53,6 +53,18 @@ public class EditCommandTest {
     }
 
     @Test
+    public void execute_noEditsMade_failure() {
+        // Test that editing first person without change leads to error
+        Person editedPerson = model.getFilteredPersonList().get(0);
+        EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).build();
+        EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, descriptor);
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_NOT_EDITED);
+
+        assertCommandFailure(editCommand, model, expectedMessage);
+    }
+
+    @Test
     public void execute_someFieldsSpecifiedUnfilteredList_success() {
         Index indexLastPerson = Index.fromOneBased(model.getFilteredPersonList().size());
         Person lastPerson = model.getFilteredPersonList().get(indexLastPerson.getZeroBased());
@@ -76,17 +88,13 @@ public class EditCommandTest {
     }
 
     @Test
-    public void execute_noFieldSpecifiedUnfilteredList_success() {
+    public void execute_noParamAddedUnfilteredList_failure() {
         EditCommand editCommand = new EditCommand(INDEX_FIRST_PERSON, new EditPersonDescriptor());
         Person editedPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
 
-        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson));
+        String expectedMessage = String.format(EditCommand.MESSAGE_NOT_EDITED);
 
-        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()),
-                new ProfData(model.getProfData()),
-                new UserPrefs());
-
-        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+        assertCommandFailure(editCommand, model, expectedMessage);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -58,9 +58,6 @@ public class EditCommandParserTest {
         // no index specified
         assertParseFailure(parser, VALID_NAME_AMY, MESSAGE_INVALID_FORMAT);
 
-        // no field specified
-        assertParseFailure(parser, "1", EditCommand.MESSAGE_NOT_EDITED);
-
         // no index and no field specified
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
     }


### PR DESCRIPTION
1. Closes #160 
* The commit fixes the order of error checks so that the correct invalid index error can be thrown first

2. Closes #150 
* Was from the previous commit that was reverted. Fixes bug when editing person without actually making any different changes

3. Closes #162 
* Dook will place the cursor behind the `> ` in the command box and that is incorrect behaviour.
* Lets correct that to place it after the '> '.
