### PR TITLE
Fix theme bug when theme is unchanged

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ThemeCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ThemeCommand.java
@@ -14,6 +14,7 @@ public class ThemeCommand extends Command {
     public static final String COMMAND_WORD = "theme";
 
     public static final String MESSAGE_SUCCESS = "Theme updated!";
+    public static final String MESSAGE_FAILURE = "Theme already %s!";
 
     public static final String MESSAGE_USAGE = ThemeCommand.COMMAND_WORD
             + " "
@@ -38,6 +39,11 @@ public class ThemeCommand extends Command {
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+
+        if (model.getTheme() == toChange) {
+            throw new CommandException(String.format(MESSAGE_FAILURE, toChange));
+        }
+
         model.setTheme(toChange);
         return new CommandResult(String.format(MESSAGE_SUCCESS, toChange), false, false, true);
     }

--- a/src/test/java/seedu/address/logic/commands/ThemeCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ThemeCommandTest.java
@@ -1,11 +1,13 @@
 package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Theme;
+import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 
@@ -17,8 +19,10 @@ public class ThemeCommandTest {
     private Model model = new ModelManager();
 
     @Test
-    public void execute_changeTheme_success() {
-        // Assuming the default theme is LIGHT
+    public void execute_changeThemeLightToDark_success() {
+        // initialize theme to light
+        model.setTheme(Theme.LIGHT);
+
         Theme expectedTheme = Theme.DARK;
         ThemeCommand themeCommand = new ThemeCommand(expectedTheme);
 
@@ -30,4 +34,18 @@ public class ThemeCommandTest {
         assertCommandSuccess(themeCommand, model, expectedMessage, expectedModel);
         assertEquals(expectedModel.getTheme(), model.getTheme());
     }
+
+    @Test
+    public void execute_changeSameTheme_failure() {
+        // initialize theme to light
+        model.setTheme(Theme.LIGHT);
+
+        // test for graceful failure when changing to light theme
+        Theme expectedTheme = Theme.LIGHT;
+        ThemeCommand themeCommand = new ThemeCommand(expectedTheme);
+
+        String expectedMessage = String.format(ThemeCommand.MESSAGE_FAILURE, Theme.LIGHT);
+        assertCommandFailure(themeCommand, model, expectedMessage);
+    }
+
 }

--- a/src/test/java/seedu/address/logic/commands/ThemeCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ThemeCommandTest.java
@@ -7,7 +7,6 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Theme;
-import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 


### PR DESCRIPTION
Dook will say theme updated whenever theme command is used, even if theme remains unchanged.

Lets fix this behaviour and throw the correct error message.