### PR TITLE
Add page break after infobox

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -491,7 +491,7 @@ Below is the expected contact list after running `delete 3`, we observe `Sarah J
 `find John` followed by `delete 1` deletes the 1st person with the name `John`.
 
 </div>
-<br>
+<div style="page-break-after: always;"></div>
 <div markdown="block" class="alert alert-danger">
 
 **:exclamation: Be careful!**<br>


### PR DESCRIPTION
Page break added to make user guide conversion to pdf more smooth to read for the user. Previous iteration truncated the UG such that it was not nice to read